### PR TITLE
Handle new scope name for C++

### DIFF
--- a/grammars/swig.cson
+++ b/grammars/swig.cson
@@ -6,6 +6,10 @@
 'patterns': [
   {
     'comment': 'SWIG files contain C or C++ code, so it\'s logical to derive from the C++ rules'
+    'include': 'source.cpp'
+  }
+  {
+    'comment': 'For compatibility with versions of Atom < 0.166'
     'include': 'source.c++'
   }
   {


### PR DESCRIPTION
In the next release of Atom (v0.166), the scope names for C++ and Objective-C++ will change from `source.c++` and `source.objc++` to `source.cpp` and `source.objcpp`. This is being done to work around some issues with CSS classes containing '+' characters. This PR adds handling for the new scope names, but will continue to handle the old ones, for compatibility with old versions of Atom.

Thanks for maintaining this package!

Refs atom/language-c#54.
